### PR TITLE
Add AlgodClient as bean

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ configurations {
 dependencies {
   // Spring
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
   // Kotlin
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
   // Other
   implementation("io.projectreactor:reactor-core:3.4.3")
+	implementation("com.algorand:algosdk:1.5.1")
 
   // Tests
   testImplementation("io.projectreactor:reactor-test:3.4.3")

--- a/src/main/kotlin/se/newton/stockpriceclient/config/AlgodConfig.kt
+++ b/src/main/kotlin/se/newton/stockpriceclient/config/AlgodConfig.kt
@@ -1,0 +1,33 @@
+package se.newton.stockpriceclient.config
+
+import com.algorand.algosdk.v2.client.common.AlgodClient
+import com.algorand.algosdk.v2.client.model.NodeStatusResponse
+import org.apache.logging.log4j.Logger
+import org.springframework.beans.factory.BeanInitializationException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import se.newton.stockpriceclient.utils.getLogger
+
+@Configuration
+class AlgodConfig(
+	@Value("\${algod.url}") val algodAddress: String,
+	@Value("\${algod.port}") val algodPort: Int,
+	@Value("\${algod.token}") val algodApiToken: String,
+) {
+	val logger: Logger = getLogger<AlgodConfig>()
+
+	@Bean
+	fun createAlgodClient(): AlgodClient =
+		AlgodClient(algodAddress, algodPort, algodApiToken).apply {
+			val status = GetStatus().execute()
+			if (!status.isSuccessful) {
+				throw BeanInitializationException("AlgodClient status check returned ${status.message()}")
+			}
+
+			val statusResponse = status.body() as NodeStatusResponse
+			logger.info("AlgodClient initialized! " +
+				"Last round: ${statusResponse.lastRound} " +
+				"(${statusResponse.timeSinceLastRound / 1_000_000_000.0} seconds ago)")
+		}
+}

--- a/src/main/kotlin/se/newton/stockpriceclient/controller/rest/AlgodTestController.kt
+++ b/src/main/kotlin/se/newton/stockpriceclient/controller/rest/AlgodTestController.kt
@@ -1,0 +1,30 @@
+package se.newton.stockpriceclient.controller.rest
+
+import com.algorand.algosdk.crypto.Address
+import com.algorand.algosdk.v2.client.common.AlgodClient
+import com.algorand.algosdk.v2.client.model.Account
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Normal REST controller for testing out the AlgodClient.
+ * Useful mostly as reference.
+ */
+@RestController
+@RequestMapping("/algod-test")
+class AlgodTestController(
+	val algod: AlgodClient
+) {
+	@GetMapping("/wallet/{address}")
+	fun getWalletData(
+		@PathVariable("address") walletAddress: String
+	) : Account {
+		val response = algod.AccountInformation(Address(walletAddress)).execute()
+		if (!response.isSuccessful) {
+			throw Exception("Lookup failed!")
+		}
+		return response.body() as Account
+	}
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,18 @@
+{
+	"properties": [
+		{
+			"name": "algod.url",
+			"type": "java.lang.String",
+			"description": "The URL for the Algorand node."
+		},
+		{
+			"name": "algod.port",
+			"type": "java.lang.String",
+			"description": "The port for the Algorand node."
+		},
+		{
+			"name": "algod.token",
+			"type": "java.lang.String",
+			"description": "The token for the Algorand node."
+		}
+	] }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   application.name: Stock Price Client
   output.ansi.enabled: always
+algod:
+  url: ${ALGOD_URL}
+  port: ${ALGOD_PORT}
+  token: ${ALGOD_TOKEN}


### PR DESCRIPTION
Adds a bean for setting up the algod client.

All bean properties must be specified through environmental variables so as to not leak them to the whole web. These environmental variables are: `ALGOD_URL`, `ALGOD_PORT` and `ALGOD_TOKEN`.